### PR TITLE
Enabling replacements to work with windows style newlines

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -25,6 +25,9 @@ func Slack(markdown string, options ...SlackConvertOptions) string {
 	// TODO: write proper regex
 	linkRegex := ".*"
 
+	// This makes sure all newlines are in the correct format, since this will otherwise cause issues with further replacements
+	markdown = strings.ReplaceAll(markdown, "\r\n", "\n")
+
 	// bold **TEXT**  -> *TEXT*
 	re = regexp.MustCompile(`(?miU)((\*\*).+(\*\*))`)
 	markdown = re.ReplaceAllStringFunc(markdown, func(s string) string {

--- a/slack_test.go
+++ b/slack_test.go
@@ -59,6 +59,7 @@ func TestSlack(t *testing.T) {
 `, Slack(`
 	### Features
 `, optWithHeadlines))
+	assert.Equal("*Features*\n\nA feature", Slack("## Features\r\n\r\nA feature", optWithHeadlines))
 
 	msgSlackHeadlinesBold := `*<https://github.com/foo/boo/compare/v1.49.3...v1.50.0|1.50.0> (2015-02-12)*
 *Features*


### PR DESCRIPTION
Window style newline (with carriage returns + new line ASCII characters, `\r\n`) will break some of the conversions.

By making sure the text does not use carriage return, this issue is mitigated.