### PR TITLE
Add new RepoName option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ func main() {
 
 	// convert to Slack markdown
 	fmt.Println("Slack: ", githubmarkdownconvertergo.Slack(markdown))
+
+	// optonally githubmarkdownconvertergo.Slack is also accepting 2'nd argument that that can be used to customize converted behavor
+	fmt.Println("Slack: ", githubmarkdownconvertergo.Slack(markdown, githubmarkdownconvertergo.SlackConvertOptions{
+		// Headlines will define if GitHub headlines will be updated to be bold text in slack
+		// there is no headlines as sucks in Slack
+		Headlines: true,
+		// Name of the git repo, used to link pull-requests/issues
+		// repo name to be given in format "<owner>/<name>" (example: eritikass/githubmarkdownconvertergo)
+		RepoName: "eritikass/githubmarkdownconvertergo",
+	})
 }
 
 ```

--- a/slack.go
+++ b/slack.go
@@ -11,6 +11,11 @@ type SlackConvertOptions struct {
 	// Headlines will define if GitHub headlines will be updated to be bold text in slack
 	// there is no headlines as sucks in Slack
 	Headlines bool
+	// Name of the git repo, used to link pull-requests/issues
+	// repo name to be given in format "<owner>/<name>" (example: eritikass/githubmarkdownconvertergo)
+	RepoName string
+	// GitHub root url, if not given "https://github.com" is used as default
+	GitHubURL string
 }
 
 // Slack returns github markdown converted to Slack
@@ -20,6 +25,11 @@ func Slack(markdown string, options ...SlackConvertOptions) string {
 	opt := SlackConvertOptions{}
 	if len(options) > 0 {
 		opt = options[0]
+	}
+
+	gitHubURL := opt.GitHubURL
+	if gitHubURL == "" {
+		gitHubURL = "https://github.com"
 	}
 
 	// TODO: write proper regex
@@ -74,6 +84,15 @@ func Slack(markdown string, options ...SlackConvertOptions) string {
 	if opt.Headlines {
 		re = regexp.MustCompile(`(?m)((^\t?[ ]{0,15}#{1,4}[ ]{1,})(.+))`)
 		markdown = re.ReplaceAllString(markdown, "*$3*")
+	}
+
+	if opt.RepoName != "" {
+		// issues, pull-requests  #<number>  => to link of given issue/pr
+		re = regexp.MustCompile(`(?m)([\s(])([#])(\d{1,10})([):\s]|$)`)
+		markdown = re.ReplaceAllStringFunc(markdown, func(s string) string {
+			match := re.FindStringSubmatch(s)
+			return fmt.Sprintf("%s<%s/%s/pull/%s|%s%s>%s", match[1], gitHubURL, opt.RepoName, match[3], match[2], match[3], match[4])
+		})
 	}
 
 	return markdown

--- a/slack_test.go
+++ b/slack_test.go
@@ -74,3 +74,25 @@ func TestSlackHeadlinesOption(t *testing.T) {
 
 	assert.Equal(msgSlackHeadlinesBold, Slack(msgGithub, optWithHeadlines))
 }
+
+func TestSlackRepoNameOption(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal("Enhance link regexp <https://github.com/eritikass/githubmarkdownconvertergo/pull/134|#134>", Slack("Enhance link regexp #134", SlackConvertOptions{
+		RepoName: "eritikass/githubmarkdownconvertergo",
+	}))
+
+	actualInput := `
+	• add GET /v1/events (#134)
+	• remove DELETE /v1/message, (#121)
+	• remove DELETE /v1/message (#121)
+	• fix UPDATE /v1/user/meta, #123`
+	expected := `
+	• add GET /v1/events (<https://github.com/foo-owner/boo-repo/pull/134|#134>)
+	• remove DELETE /v1/message, (<https://github.com/foo-owner/boo-repo/pull/121|#121>)
+	• remove DELETE /v1/message (<https://github.com/foo-owner/boo-repo/pull/121|#121>)
+	• fix UPDATE /v1/user/meta, <https://github.com/foo-owner/boo-repo/pull/123|#123>`
+	assert.Equal(expected, Slack(actualInput, SlackConvertOptions{
+		RepoName: "foo-owner/boo-repo",
+	}))
+}

--- a/slack_test.go
+++ b/slack_test.go
@@ -37,6 +37,11 @@ func TestSlack(t *testing.T) {
 
 	assert.Equal(listSlack, Slack(listGithub))
 
+}
+
+func TestSlackHeadlinesOption(t *testing.T) {
+	assert := assert.New(t)
+
 	// release message
 	msgGithub := `# [1.50.0](https://github.com/foo/boo/compare/v1.49.3...v1.50.0) (2015-02-12)
 ### Features


### PR DESCRIPTION
to link repo issues/pull requests 


example with `RepoName: "eritikass/githubmarkdownconvertergo"`

github markdown
```
Enhance link regexp #134
``` 

would become slack markdown
```
Enhance link regexp <https://github.com/eritikass/githubmarkdownconvertergo/pull/134|#134>
```