### PR TITLE
Add new optional CustomRefPatterns param

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ func main() {
 		// repo name to be given in format "<owner>/<name>" (example: eritikass/githubmarkdownconvertergo)
 		// optional: default not used
 		RepoName: "eritikass/githubmarkdownconvertergo",
+		// CustomRefPatterns is optional list of replacement patterns to easily link tickets to alternative systems
+		// optional: default not used
+		CustomRefPatterns: map[string]string{
+			// key is patterns that is searched using regex from markdown (try out using https://regex101.com/)
+			// any capture groups you define there can be used in value. 
+			// NB: only capture groups by name can be accessed, do no try to use via index.
+			`JIRA-(?P<ID>\d+)`: "https://test.atlassian.net/browse/JIRA-${ID})",
+			`(?P<BOARD>DEVOPS|LEGAL|COPY|PASTA)-(?P<ID>\d+)`: "[${BOARD}-${ID}](https://xxx.atlassian.net/browse/${BOARD}-${ID})",
+			`eventum-(?P<ID>\d+)`: "https://eventum.example.com/issue.php?id=${ID}",
+			`ticket-(?P<ID>\d+)`:  "<https://example.com/t/${ID}|ticket:${ID}>",
+		},
 	})
 }
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func main() {
 		CustomRefPatterns: map[string]string{
 			// key is patterns that is searched using regex from markdown (try out using https://regex101.com/)
 			// any capture groups you define there can be used in value. 
-			// NB: only capture groups by name can be accessed, do no try to use via index.
+			// NB: only capture groups by name can be accessed, do not try to use via index.
 			`JIRA-(?P<ID>\d+)`: "https://test.atlassian.net/browse/JIRA-${ID})",
 			`(?P<BOARD>DEVOPS|LEGAL|COPY|PASTA)-(?P<ID>\d+)`: "[${BOARD}-${ID}](https://xxx.atlassian.net/browse/${BOARD}-${ID})",
 			`eventum-(?P<ID>\d+)`: "https://eventum.example.com/issue.php?id=${ID}",

--- a/slack.go
+++ b/slack.go
@@ -39,7 +39,11 @@ func Slack(markdown string, options ...SlackConvertOptions) string {
 		startOfPattern := `(?P<THE_START_OF_MATCH>^|[\s\[\(])`
 		endOfPattern := `(?P<THE_END_OF_MATCH>$|[\s:\]\),.!])`
 		for pattern, replace := range opt.CustomRefPatterns {
-			re = regexp.MustCompile(fmt.Sprintf(`%s%s%s`, startOfPattern, pattern, endOfPattern))
+			re, err := regexp.Compile(fmt.Sprintf(`%s%s%s`, startOfPattern, pattern, endOfPattern))
+			if err != nil {
+				println("ERROR_USING_CustomRefPatterns: " + err.Error())
+				continue
+			}
 			markdown = re.ReplaceAllString(markdown, fmt.Sprintf(`${THE_START_OF_MATCH}%s${THE_END_OF_MATCH}`, replace))
 		}
 	}

--- a/slack.go
+++ b/slack.go
@@ -16,6 +16,8 @@ type SlackConvertOptions struct {
 	RepoName string
 	// GitHub root url, if not given "https://github.com" is used as default
 	GitHubURL string
+	// CustomRefPatterns is list of patterns used to replace
+	CustomRefPatterns map[string]string
 }
 
 // Slack returns github markdown converted to Slack
@@ -30,6 +32,16 @@ func Slack(markdown string, options ...SlackConvertOptions) string {
 	gitHubURL := opt.GitHubURL
 	if gitHubURL == "" {
 		gitHubURL = "https://github.com"
+	}
+
+	if len(opt.CustomRefPatterns) > 0 {
+		// using start and end patterns make sure we will not find match middle of the word etc.
+		startOfPattern := `(?P<THE_START_OF_MATCH>^|[\s\[\(])`
+		endOfPattern := `(?P<THE_END_OF_MATCH>$|[\s:\]\),.!])`
+		for pattern, replace := range opt.CustomRefPatterns {
+			re = regexp.MustCompile(fmt.Sprintf(`%s%s%s`, startOfPattern, pattern, endOfPattern))
+			markdown = re.ReplaceAllString(markdown, fmt.Sprintf(`${THE_START_OF_MATCH}%s${THE_END_OF_MATCH}`, replace))
+		}
 	}
 
 	// TODO: write proper regex

--- a/slack_test.go
+++ b/slack_test.go
@@ -113,3 +113,74 @@ func TestSlackRepoNameOption(t *testing.T) {
 	}))
 
 }
+
+func TestSlackCustomRefPatterns(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal("https://xxx.atlassian.net/browse/JIRA-35", Slack("JIRA-35", SlackConvertOptions{
+		CustomRefPatterns: map[string]string{
+			`(?P<BOARD>JIRA|DEVOPS)-(?P<ID>\d+)`: "https://xxx.atlassian.net/browse/${BOARD}-${ID}",
+		},
+	}))
+
+	assert.Equal(" https://xxx.atlassian.net/browse/JIRA-1   ", Slack(" JIRA-1   ", SlackConvertOptions{
+		CustomRefPatterns: map[string]string{
+			`JIRA-(?P<ID>\d+)`: "https://xxx.atlassian.net/browse/JIRA-${ID}",
+		},
+	}))
+
+	assert.Equal(" [https://xxx.atlassian.net/browse/JIRA-1]   ", Slack(" [JIRA-1]   ", SlackConvertOptions{
+		CustomRefPatterns: map[string]string{
+			`JIRA-(?P<ID>\d+)`: "https://xxx.atlassian.net/browse/JIRA-${ID}",
+		},
+	}))
+
+	assert.Equal(" (https://xxx.atlassian.net/browse/JIRA-1)   ", Slack(" (JIRA-1)   ", SlackConvertOptions{
+		CustomRefPatterns: map[string]string{
+			`JIRA-(?P<ID>\d+)`: "https://xxx.atlassian.net/browse/JIRA-${ID}",
+		},
+	}))
+	assert.Equal(" (https://xxx.atlassian.net/browse/JIRA-1, https://xxx.atlassian.net/browse/JIRA-23)   ", Slack(" (JIRA-1, UPS-23)   ", SlackConvertOptions{
+		CustomRefPatterns: map[string]string{
+			`(?P<BOARD>JIRA|UPS)-(?P<ID>\d+)`: "https://xxx.atlassian.net/browse/JIRA-${ID}",
+		},
+	}))
+
+	assert.Equal("https://xxx.atlassian.net/browse/JIRA-356", Slack("JIRA-356", SlackConvertOptions{
+		CustomRefPatterns: map[string]string{
+			`(?P<BOARD>JIRA|DEVOPS)-(?P<ID>\d{1,10})`: "https://xxx.atlassian.net/browse/${BOARD}-${ID}",
+		},
+	}))
+
+	assert.Equal("XXX https://xxx.atlassian.net/browse/JIRA-12 UUU", Slack("XXX JIRA-12 UUU", SlackConvertOptions{
+		CustomRefPatterns: map[string]string{
+			`JIRA-(?P<ID>\d+)`: "https://xxx.atlassian.net/browse/JIRA-${ID}",
+		},
+	}))
+
+	assert.Equal("XXXJIRA-2YYY", Slack("XXXJIRA-2YYY", SlackConvertOptions{
+		CustomRefPatterns: map[string]string{
+			`JIRA-(?P<ID>\d+)`: "https://xxx.atlassian.net/browse/JIRA-${ID}",
+		},
+	}))
+
+	assert.Equal(`
+- <https://xxx.atlassian.net/browse/JIRA-666|JIRA-666>: foo-booo
+- <https://eventum.example.com/issue.php?id=1335|eventum-1335>: cat was here (<https://xxx.atlassian.net/browse/LEGAL-19|LEGAL-19>)
+- <https://example.com/t/555|ticket-555>: lorem ipsum something-something`, Slack(`
+- JIRA-666: foo-booo
+- eventum-1335: cat was here (LEGAL-19)
+- ticket:555: lorem ipsum something-something`, SlackConvertOptions{
+		CustomRefPatterns: map[string]string{
+			`(?P<BOARD>JIRA|DEVOPS|LEGAL|COPY|PASTA)-(?P<ID>\d+)`: "[${BOARD}-${ID}](https://xxx.atlassian.net/browse/${BOARD}-${ID})",
+			`eventum-(?P<ID>\d+)`: "[eventum-${ID}](https://eventum.example.com/issue.php?id=${ID})",
+			`ticket:(?P<ID>\d+)`:  "<https://example.com/t/${ID}|ticket-${ID}>",
+		},
+	}))
+
+	assert.Equal("https://example.com", Slack("example_com", SlackConvertOptions{
+		CustomRefPatterns: map[string]string{
+			`example_com`: "https://example.com",
+		},
+	}))
+}

--- a/slack_test.go
+++ b/slack_test.go
@@ -164,17 +164,28 @@ func TestSlackCustomRefPatterns(t *testing.T) {
 		},
 	}))
 
-	assert.Equal(`
-- <https://xxx.atlassian.net/browse/JIRA-666|JIRA-666>: foo-booo
-- <https://eventum.example.com/issue.php?id=1335|eventum-1335>: cat was here (<https://xxx.atlassian.net/browse/LEGAL-19|LEGAL-19>)
-- <https://example.com/t/555|ticket-555>: lorem ipsum something-something`, Slack(`
-- JIRA-666: foo-booo
-- eventum-1335: cat was here (LEGAL-19)
-- ticket:555: lorem ipsum something-something`, SlackConvertOptions{
+	inputLong := `
+	- JIRA-666: foo-booo (leg-123)
+	- eventum-1335: cat was here (LEGAL-19)
+	- ticket:555: lorem ipsum something-something`
+	expectedLong := `
+	- <https://xxx.atlassian.net/browse/JIRA-666|JIRA-666>: foo-booo (leg-123)
+	- <https://eventum.example.com/issue.php?id=1335|eventum-1335>: cat was here (<https://xxx.atlassian.net/browse/LEGAL-19|LEGAL-19>)
+	- <https://example.com/t/555|ticket-555>: lorem ipsum something-something`
+
+	assert.Equal(expectedLong, Slack(inputLong, SlackConvertOptions{
 		CustomRefPatterns: map[string]string{
 			`(?P<BOARD>JIRA|DEVOPS|LEGAL|COPY|PASTA)-(?P<ID>\d+)`: "[${BOARD}-${ID}](https://xxx.atlassian.net/browse/${BOARD}-${ID})",
 			`eventum-(?P<ID>\d+)`: "[eventum-${ID}](https://eventum.example.com/issue.php?id=${ID})",
 			`ticket:(?P<ID>\d+)`:  "<https://example.com/t/${ID}|ticket-${ID}>",
+		},
+	}))
+
+	assert.Equal(expectedLong, Slack(inputLong, SlackConvertOptions{
+		CustomRefPatterns: map[string]string{
+			`(?P<BOARD>[A-Z]{3,10})-(?P<ID>\d{2,5})`: "[${BOARD}-${ID}](https://xxx.atlassian.net/browse/${BOARD}-${ID})",
+			`eventum-(?P<ID>\d+)`:                    "[eventum-${ID}](https://eventum.example.com/issue.php?id=${ID})",
+			`ticket:(?P<ID>\d+)`:                     "<https://example.com/t/${ID}|ticket-${ID}>",
 		},
 	}))
 


### PR DESCRIPTION
That can be used to easily link any custom patterns, ticket-refs (example: JIRA) in our markdown.